### PR TITLE
Fix typo: "Hidgh" to "High"

### DIFF
--- a/volume_control.py
+++ b/volume_control.py
@@ -32,7 +32,7 @@ def parse_volume(s, default = 10):
         return default
 
 def process_query(q):
-    results = [] 
+    results = []
     if(len(q) == 0):
         results.append(alfred.Item(
             attributes = {'arg': '', 'valid': 'false'},
@@ -118,7 +118,7 @@ def process_query(q):
     if('high'.startswith(op)):
         results.append(alfred.Item(
             attributes = {'arg': '75', 'autocomplete': 'high'},
-            title = "Hidgh Volume: 75%",
+            title = "High Volume: 75%",
             subtitle = "vol high"
         ))
 


### PR DESCRIPTION
Thanks for making this workflow. Just saw this typo when browsing the code. Atom also automatically fixed a few whitespace issues, if that's okay.
